### PR TITLE
Chore/double tap gesture skip button

### DIFF
--- a/echoes/Scenes/SceneOpening.swift
+++ b/echoes/Scenes/SceneOpening.swift
@@ -1,17 +1,13 @@
-//
 //  SceneOpening.swift
-//  echoes
-//
-//  Created by Elyora Dior on 16/10/24.
-//
 
 import UIKit
 import AVKit
 
 class SceneOpening: UIViewController {
-
+    
     var player: AVPlayer?
-
+    var skipButton: UIButton?
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         
@@ -28,28 +24,29 @@ class SceneOpening: UIViewController {
             self.view.addSubview(playerViewController.view)
             playerViewController.view.frame = self.view.bounds
             playerViewController.didMove(toParent: self)
-
+            
             // Play video
             player?.play()
-
+            
             // Add observer for when the video finishes playing
             NotificationCenter.default.addObserver(self, selector: #selector(videoDidFinishPlaying), name: .AVPlayerItemDidPlayToEndTime, object: player?.currentItem)
             
-            // Add tap gesture to skip video
-//            let tapGesture = UITapGestureRecognizer(target: self, action: #selector(skipVideo))
-//            self.view.addGestureRecognizer(tapGesture)
-
+            // Add double tap gesture to show skip button
+            let doubleTapGesture = UITapGestureRecognizer(target: self, action: #selector(showSkipButton))
+            doubleTapGesture.numberOfTapsRequired = 2
+            self.view.addGestureRecognizer(doubleTapGesture)
+            
         } else {
             print("Video file not found.")
         }
     }
-
+    
     @objc func videoDidFinishPlaying() {
         print("Video finished playing")
-
+        
         // Remove observer
         NotificationCenter.default.removeObserver(self, name: .AVPlayerItemDidPlayToEndTime, object: player?.currentItem)
-
+        
         // Transition to GameViewController (Scene 1)
         let gameVC = GameViewController()
         gameVC.modalPresentationStyle = .fullScreen
@@ -58,13 +55,44 @@ class SceneOpening: UIViewController {
         }
     }
     
+    @objc func showSkipButton() {
+        if skipButton == nil {
+            skipButton = UIButton(type: .system)
+            skipButton?.setTitle("Skip", for: .normal)
+            skipButton?.backgroundColor = UIColor.black.withAlphaComponent(0.5)
+            skipButton?.setTitleColor(.white, for: .normal)
+            skipButton?.layer.cornerRadius = 5
+            
+            if let customFont = UIFont(name: "MetalMania-Regular", size: 20) {
+                skipButton?.titleLabel?.font = customFont
+            } else {
+                print("Failed to load MetalMania-Regular font.")
+            }
+            
+            if let button = skipButton {
+                let buttonWidth: CGFloat = 60
+                let buttonHeight: CGFloat = 30
+                button.frame = CGRect(x: self.view.bounds.width - buttonWidth - 20, y: 20, width: buttonWidth, height: buttonHeight)
+                self.view.addSubview(button)
+            }
+            
+            skipButton?.addTarget(self, action: #selector(skipVideo), for: .touchUpInside)
+        }
+    }
+    
     @objc func skipVideo() {
         print("Video skipped by user")
         
         // Pause and clean up the player
         player?.pause()
-        player = nil // Optionally release the player
-
+        
+        // Optionally release the player
+        player = nil
+        
+        // Remove skip button from view
+        skipButton?.removeFromSuperview()
+        skipButton = nil
+        
         // Call the same function when the video finishes
         videoDidFinishPlaying()
     }


### PR DESCRIPTION
Implement a double-tap gesture that displays a skip button in the top-right corner, replaces the single-tap gesture with a double-tap gesture that triggers the display of a skip button. When the skip button is clicked, it will skip the scene 1 video. 
 
#### Key Changes 
- The single-tap gesture was replaced with a UITapGestureRecognizer configured for double-tap 
(numberOfTapsRequired = 2). 
- Double-tapping triggers the showSkipButton method. 
- A UIButton is created and shown in the top-right corner when the double-tap gesture is detected. 
- Clicking the button triggers the skipVideo method, skipping the video. 
- The skip button is semi-transparent, rounded, and positioned at the top-right of the screen. 